### PR TITLE
Group activity types

### DIFF
--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -1,10 +1,10 @@
-import { DataSpeedAvg } from '../data/data.speed-avg';
-import { DataPaceAvg } from '../data/data.pace-avg';
-import { DataSwimPaceAvg } from '../data/data.swim-pace-avg';
-import { DataPace } from '../data/data.pace';
-import { DataSpeed } from '../data/data.speed';
-import { DataSwimPace } from '../data/data.swim-pace';
-import { DataVerticalSpeedAvg } from '../data/data.vertical-speed-avg';
+import {DataSpeedAvg} from '../data/data.speed-avg';
+import {DataPaceAvg} from '../data/data.pace-avg';
+import {DataSwimPaceAvg} from '../data/data.swim-pace-avg';
+import {DataPace} from '../data/data.pace';
+import {DataSpeed} from '../data/data.speed';
+import {DataSwimPace} from '../data/data.swim-pace';
+import {DataVerticalSpeedAvg} from '../data/data.vertical-speed-avg';
 
 export class ActivityTypesHelper {
   static getActivityTypesAsUniqueArray(): string[] {
@@ -61,6 +61,10 @@ export class ActivityTypesHelper {
 
 /**
  * This enum works like a all matchers for normalized sport types between different naming across services
+ *
+ * It helps as you can call request an activity type with different namin eg .BackCountrySki or .BackCountrySkiing and get a uniform value
+ * Also helps in case you have peristed data that do not match or have been peristed wrongly
+ *
  */
 export enum ActivityTypes {
   'unknown' = 'Unknown sport',
@@ -78,6 +82,7 @@ export enum ActivityTypes {
   'multisport' = 'Multisport',
   'running_virtual_activity' = 'Virtual Running',
   'VirtualRun' = 'Virtual Running',
+  'Virtual Running' = 'Virtual Running',
   'Run' = 'Running',
   'run' = 'Running',
   'running_track' = 'Running',
@@ -92,9 +97,11 @@ export enum ActivityTypes {
   'cycling_gravel_cycling' = 'Cycling',
   'Biking' = 'Cycling',
   'biking' = 'Cycling',
-  'e_biking' = 'E Biking',
-  'E Biking' = 'E Biking',
-  'EBikeRide' = 'E Biking',
+  'e_biking' = 'E-Biking',
+  'E Biking' = 'E-Biking',
+  'E biking' = 'E-Biking',
+  'EBikeRide' = 'E-Biking',
+  'E-Biking' = 'E-Biking',
   'Ride' = 'Cycling',
   'cycling_mountain' = 'Mountain biking',
   'MountainBiking' = 'Mountain biking',
@@ -144,6 +151,7 @@ export enum ActivityTypes {
   'Indoor Cycling' = 'Indoor Cycling',
   'cycling_virtual_activity' = 'Virtual Cycling',
   'VirtualRide' = 'Virtual Cycling',
+  'Virtual Cycling' = 'Virtual Cycling',
   'Circuit training' = 'Circuit training',
   'Triathlon' = 'Triathlon',
   'Alpine skiing' = 'Alpine skiing',
@@ -162,8 +170,10 @@ export enum ActivityTypes {
   'Crosscountry skiing' = 'Crosscountry Skiing',
   'Crosscountry Skiing' = 'Crosscountry Skiing',
   'cross_country_skiing' = 'Crosscountry Skiing',
-  'NordicSki' = 'Crosscountry Skiing',
+  'NordicSki' = 'Nordic Skiing',
+  'Nordic Skiing' = 'Nordic Skiing',
   'backcountry' = 'Crosscountry Skiing',
+  'BackCountrySki' = 'Crosscountry Skiing',
   'downhill' = 'Downhill skiing',
   'Downhill skiing' = 'Downhill skiing',
   'Weight training' = 'Weight training',
@@ -214,6 +224,8 @@ export enum ActivityTypes {
   'ice_skating' = 'Ice Skating',
   'ice skating' = 'Ice Skating',
   'Ice skating' = 'Ice Skating',
+  'IceSkate' = 'Ice Skating',
+  'Ice Skate' = 'Ice Skating',
   'fitness_equipment_indoor_rowing' = 'Indoor Rowing',
   'Indoor Rowing' = 'Indoor Rowing',
   'indoor_rowing' = 'Indoor Rowing',
@@ -293,6 +305,7 @@ export enum ActivityTypes {
   'route' = 'Route',
   'Route' = 'Route',
   'inline_skating' = 'Inline Skating',
+  'InlineSkating' = 'Inline Skating',
   'Inline Skating' = 'Inline Skating',
   'Inline skating' = 'Inline Skating',
   'InlineSkate' = 'Inline Skating',
@@ -336,10 +349,11 @@ export enum ActivityTypes {
   'Elliptical' = 'Elliptical trainer',
   'Crossfit' = 'Cross fit',
   'Handcycle' = 'Hand cycle',
-  'IceSkate' = 'Ice Skate',
   'StairStepper' = 'Stair Stepper',
+  'Stair Stepper' = 'Stair Stepper',
   'Velomobile' = 'Velomobile',
   'Wheelchair' = 'Wheel chair',
+  'Wheel chair' = 'Wheel chair',
   'Workout' = 'Workout',
 }
 
@@ -347,38 +361,38 @@ export enum ActivityTypes {
 export class StravaGPXTypeMapping {
 
   public static readonly map: Array<{ id: number, type: string }> = [
-    {id: 1, type: 'Ride'},
-    {id: 2, type: 'AlpineSki'},
-    {id: 3, type: 'BackcountrySki'},
-    {id: 4, type: 'Hike'},
-    {id: 5, type: 'IceSkate'},
-    {id: 6, type: 'InlineSkate'},
-    {id: 7, type: 'NordicSki'},
-    {id: 8, type: 'RollerSki'},
-    {id: 9, type: 'Run'},
-    {id: 10, type: 'Walk'},
-    {id: 11, type: 'Workout'},
-    {id: 12, type: 'Snowboard'},
-    {id: 13, type: 'Snowshoe'},
-    {id: 14, type: 'Kitesurf'},
-    {id: 15, type: 'Windsurf'},
-    {id: 16, type: 'Swim'},
-    {id: 17, type: 'VirtualRide'},
-    {id: 18, type: 'EBikeRide'},
-    {id: 19, type: 'Velomobile'},
-    {id: 21, type: 'Canoeing'},
-    {id: 22, type: 'Kayaking'},
-    {id: 23, type: 'Rowing'},
-    {id: 24, type: 'StandUpPaddling'},
-    {id: 25, type: 'Surfing'},
-    {id: 26, type: 'Crossfit'},
-    {id: 27, type: 'Elliptical'},
-    {id: 28, type: 'RockClimbing'},
-    {id: 29, type: 'StairStepper'},
-    {id: 30, type: 'WeightTraining'},
-    {id: 31, type: 'Yoga'},
-    {id: 51, type: 'Handcycle'},
-    {id: 52, type: 'Wheelchair'},
-    {id: 53, type: 'VirtualRun'}
+    {id: 1, type: ActivityTypes.Cycling},
+    {id: 2, type: ActivityTypes.AlpineSKi},
+    {id: 3, type: ActivityTypes.BackCountrySki},
+    {id: 4, type: ActivityTypes.Hiking},
+    {id: 5, type: ActivityTypes.IceSkate},
+    {id: 6, type: ActivityTypes.InlineSkate},
+    {id: 7, type: ActivityTypes.NordicSki},
+    {id: 8, type: ActivityTypes.RollerSki},
+    {id: 9, type: ActivityTypes.Running},
+    {id: 10, type: ActivityTypes.Walking},
+    {id: 11, type: ActivityTypes.Workout},
+    {id: 12, type: ActivityTypes.Snowboard},
+    {id: 13, type: ActivityTypes.Snowshoeing},
+    {id: 14, type: ActivityTypes.Kitesurfing},
+    {id: 15, type: ActivityTypes.Windsurfing},
+    {id: 16, type: ActivityTypes.Swimming},
+    {id: 17, type: ActivityTypes.VirtualRide},
+    {id: 18, type: ActivityTypes.EBikeRide},
+    {id: 19, type: ActivityTypes.Velomobile},
+    {id: 21, type: ActivityTypes.Canoeing},
+    {id: 22, type: ActivityTypes.Kayaking},
+    {id: 23, type: ActivityTypes.Rowing},
+    {id: 24, type: ActivityTypes.StandUpPaddling},
+    {id: 25, type: ActivityTypes.Surfing},
+    {id: 26, type: ActivityTypes.Crossfit},
+    {id: 27, type: ActivityTypes.Elliptical},
+    {id: 28, type: ActivityTypes.RockClimbing},
+    {id: 29, type: ActivityTypes.StairStepper},
+    {id: 30, type: ActivityTypes.WeightTraining},
+    {id: 31, type: ActivityTypes.Yoga},
+    {id: 51, type: ActivityTypes.Handcycle},
+    {id: 52, type: ActivityTypes.Wheelchair},
+    {id: 53, type: ActivityTypes.VirtualRun}
   ];
 }

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -76,7 +76,7 @@ export class ActivityTypesHelper {
    * @param activityType
    */
   static getActivityGroupForActivityType(activityType: ActivityTypes): ActivityTypeGroups {
-    return ActivityTypeGroups[<keyof typeof ActivityTypeGroups>ActivityTypesHelper.getActivityTypeGroupsAsUniqueArray().find(activityTypeGroupString => {
+    return ActivityTypeGroups[<keyof typeof ActivityTypeGroups>ActivityTypesHelper.getActivityTypeGroupsAsUniqueArray().find(activityTypeGroupString => { // Could also iterate over the map
       return ActivityTypesGroupMapping.map[<keyof typeof ActivityTypeGroups>activityTypeGroupString].find(groupItem => groupItem === activityType)
     }) || ActivityTypeGroups.Unspecified];
   }

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -745,6 +745,18 @@ export enum ActivityTypes {
   'Workout' = 'Workout',
 }
 
+export enum ActivityTypeGroups {
+  'Running' = 'Running',
+  'Cycling' = 'Cycling',
+  'Performance' = 'Performance',
+  'Indoor Sports' = 'Indoor Sports',
+  'Outdoor Adventures' = 'Outdoor Adventures',
+  'Winter Sports' = 'Winter Sports',
+  'Water Sports' = 'Water Sports',
+  'Diving' = 'Diving',
+  'Team racket' = 'Team Racket',
+  'Unspecified' = 'Unspecified',
+}
 
 export class StravaGPXTypeMapping {
 

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -878,6 +878,7 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.RacquetBall,
       ActivityTypes.TableTennis,
       ActivityTypes.Tennis,
+      // @todo add more
     ]
   };
 

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -26,15 +26,14 @@ export class ActivityTypesHelper {
     switch (activityType) {
       case ActivityTypes.Running:
         return [DataPaceAvg.type];
-      case ActivityTypes['Trail Running']:
+      case ActivityTypes.TrailRunning:
         return [DataPaceAvg.type, DataVerticalSpeedAvg.type];
       case ActivityTypes.Treadmill:
-      case ActivityTypes['Track and Field']:
-      case ActivityTypes['Elliptical trainer']:
+      case ActivityTypes.TrackAndField:
+      case ActivityTypes.EllipticalTrainer:
         return [DataPaceAvg.type];
       case ActivityTypes.Swimming:
-      case ActivityTypes['Open Water Swimming']:
-      case ActivityTypes.swimming_lap_swimming:
+      case ActivityTypes.OpenWaterSwimming:
         return [DataSpeedAvg.type, DataSwimPaceAvg.type];
       default:
         return [DataSpeedAvg.type];
@@ -44,14 +43,13 @@ export class ActivityTypesHelper {
   static speedDerivedMetricsToUseForActivityType(activityType: ActivityTypes): string[] {
     switch (activityType) {
       case ActivityTypes.Running:
-      case ActivityTypes['Trail Running']:
+      case ActivityTypes.TrailRunning:
       case ActivityTypes.Treadmill:
-      case ActivityTypes['Track and Field']:
-      case ActivityTypes['Elliptical trainer']:
+      case ActivityTypes.TrackAndField:
+      case ActivityTypes.EllipticalTrainer:
         return [DataPace.type];
       case ActivityTypes.Swimming:
-      case ActivityTypes['Open Water Swimming']:
-      case ActivityTypes.swimming_lap_swimming:
+      case ActivityTypes.OpenWaterSwimming:
         return [DataSpeed.type, DataSwimPace.type];
       default:
         return [DataSpeed.type];
@@ -65,30 +63,79 @@ export class ActivityTypesHelper {
  * It helps as you can call request an activity type with different namin eg .BackCountrySki or .BackCountrySkiing and get a uniform value
  * Also helps in case you have peristed data that do not match or have been peristed wrongly
  *
+ * Important: don't forget to decalare the original string value aka: 'Running' = 'Running'
+ *
+ * @todo how do we write activity names? Is it Alpine skiing? or Alpine Skiing? For now I used uppercase each word
  */
 export enum ActivityTypes {
-  'unknown' = 'Unknown sport',
-  'Unknown sport' = 'Unknown sport',
-  'undefined' = 'Unknown sport',
+  /**
+   * Unknown sport
+   */
+  'unknown' = 'Unknown Sport',
+  'Unknown sport' = 'Unknown Sport',
+  'Unknown Sport' = 'Unknown Sport',
+  'undefined' = 'Unknown Sport',
+  'Not specified sport' = 'Unknown Sport',
+  'Other' = 'Unknown Sport', // @todo is this correct?
+  /**
+   * Generic
+   */
   'generic' = 'Generic',
   'Generic' = 'Generic',
+  /**
+   * Transition
+   */
   'transition' = 'Transition',
   'Transition' = 'Transition',
+  /**
+   * Fitness Equipment
+   */
   'fitness_equipment' = 'Fitness Equipment',
   'Fitness Equipment' = 'Fitness Equipment',
-  'Not specified sport' = 'Unknown sport',
-  'Other' = 'Unknown sport',
+
+  /**
+   * Multisport
+   */
   'Multisport' = 'Multisport',
+  'MultiSport' = 'Multisport',
   'multisport' = 'Multisport',
+
+  /**
+   * Virtual Running
+   */
   'running_virtual_activity' = 'Virtual Running',
   'VirtualRun' = 'Virtual Running',
+  'Virtual running' = 'Virtual Running',
   'Virtual Running' = 'Virtual Running',
+  /**
+   * Running
+   */
   'Run' = 'Running',
   'run' = 'Running',
   'running_track' = 'Running',
   'running_trail' = 'Trail Running',
   'Running' = 'Running',
   'running' = 'Running',
+  'running_street' = 'Running',
+  'running_road' = 'Running',
+  /**
+   * Trail Running
+   */
+  'TrailRunning' = 'Trail Running',
+  'Trail Running' = 'Trail Running',
+  'Trail running' = 'Trail Running',
+  'trail_running' = 'Trail Running',
+  'trail' = 'Trail Running', // @todo hack?
+  /**
+   * Indoor Running
+   */
+  'Indoor running' = 'Indoor Running',
+  'Indoor Running' = 'Indoor Running',
+  'running_indoor' = 'Indoor Running',
+  'running_indoor_running' = 'Indoor Running',
+  /**
+   * Cycling
+   */
   'Cycling' = 'Cycling',
   'cycling' = 'Cycling',
   'cycling_road' = 'Cycling',
@@ -97,263 +144,604 @@ export enum ActivityTypes {
   'cycling_gravel_cycling' = 'Cycling',
   'Biking' = 'Cycling',
   'biking' = 'Cycling',
+  'Ride' = 'Cycling',
+  /**
+   * Indoor Cycling
+   */
+    'cycling_indoor_cycling' = 'Indoor Cycling',
+  'Indoorcycling' = 'Indoor Cycling',
+  'indoor_cycling' = 'Indoor Cycling',
+  'Indoor cycling' = 'Indoor Cycling',
+  'Indoor Cycling' = 'Indoor Cycling',
+  /**
+   * Virtual Cycling
+   */
+    'cycling_virtual_activity' = 'Virtual Cycling',
+  'VirtualRide' = 'Virtual Cycling',
+  'Virtual Cycling' = 'Virtual Cycling',
+  'Circuit training' = 'Circuit training',
+  /**
+   * E-Biking
+   */
   'e_biking' = 'E-Biking',
   'E Biking' = 'E-Biking',
   'E biking' = 'E-Biking',
   'EBikeRide' = 'E-Biking',
   'E-Biking' = 'E-Biking',
-  'Ride' = 'Cycling',
-  'cycling_mountain' = 'Mountain biking',
-  'MountainBiking' = 'Mountain biking',
-  'Mountain Biking' = 'Mountain biking',
-  'cycling_cyclocross' = 'Mountain biking',
-  'mountain' = 'Mountain biking',
-  'Mountain biking' = 'Mountain biking',
+  /**
+   * Mountain biking
+   */
+  'cycling_mountain' = 'Mountain Biking',
+  'MountainBiking' = 'Mountain Biking',
+  'Mountain Biking' = 'Mountain Biking',
+  'cycling_cyclocross' = 'Mountain Biking',
+  'mountain' = 'Mountain Biking', // @todo this feels hacky but exists and indeed it's MTB
+  'Mountain biking' = 'Mountain Biking',
+  /**
+   * Motorcycling
+   */
   'motorcycling' = 'Motorcycling',
   'Motorcycling' = 'Motorcycling',
+  /**
+   * Boating
+   */
   'boating' = 'Boating',
   'Boating' = 'Boating',
+  /**
+   * Driving
+   */
   'driving' = 'Driving',
   'Driving' = 'Driving',
+  /**
+   * Swimming
+   */
   'Swimming' = 'Swimming',
   'swimming' = 'Swimming',
   'Swim' = 'Swimming',
   'swim' = 'Swimming',
+  'swimming_lap_swimming' = 'Swimming',
+  /**
+   * Open Water Swimming
+   */
+  'swimming_open_water' = 'Open Water Swimming',
+  'Open water swimming' = 'Open Water Swimming',
+  'open water swimming' = 'Open Water Swimming',
+  'Open Water Swimming' = 'Open Water Swimming',
+  'OpenWaterSwimming' = 'Open Water Swimming',
+  'open_water' = 'Open Water Swimming',
+  /**
+   * Basketball
+   */
   'basketball' = 'Basketball',
+  /**
+   * Soccer
+   */
   'soccer' = 'Soccer',
+  'Soccer' = 'Soccer',
+  /**
+   * American Football
+   */
   'american_football' = 'American Football',
   'American footBall' = 'American Football',
   'American Football' = 'American Football',
+  /**
+   * Skating
+   */
   'Skating' = 'Skating',
+  /**
+   * Aerobics
+   */
   'Aerobics' = 'Aerobics',
-  'YogaPilates' = 'YogaPilates',
+  /**
+   * Yoga
+   */
   'training_yoga' = 'Yoga',
   'yoga' = 'Yoga',
   'Yoga' = 'Yoga',
+  'YogaPilates' = 'Yoga',
+  /**
+   * Trekking
+   */
   'Trekking' = 'Trekking',
+  'Trek' = 'Trekking',
+  /**
+   * Walking
+   */
   'Walking' = 'Walking',
   'walking' = 'Walking',
   'Walk' = 'Walking',
   'walk' = 'Walking',
+  /**
+   * Sailing
+   */
   'Sailing' = 'Sailing',
   'sailing' = 'Sailing',
+  /**
+   * Kayaking
+   */
   'Kayaking' = 'Kayaking',
   'kayaking' = 'Kayaking',
+  /**
+   * Rafting
+   */
   'rafting' = 'Rafting',
   'Rafting' = 'Rafting',
+  /**
+   * Rowing
+   */
   'rowing' = 'Rowing',
   'Rowing' = 'Rowing',
+  /**
+   * Indoor Rowing
+   */
+    'fitness_equipment_indoor_rowing' = 'Indoor Rowing',
+  'Indoor Rowing' = 'Indoor Rowing',
+  'indoor_rowing' = 'Indoor Rowing',
+  /**
+   * Climbing
+   */
   'Climbing' = 'Climbing',
-  'cycling_indoor_cycling' = 'Indoor Cycling',
-  'Indoorcycling' = 'Indoor Cycling',
-  'indoor_cycling' = 'Indoor Cycling',
-  'Indoor cycling' = 'Indoor Cycling',
-  'Indoor Cycling' = 'Indoor Cycling',
-  'cycling_virtual_activity' = 'Virtual Cycling',
-  'VirtualRide' = 'Virtual Cycling',
-  'Virtual Cycling' = 'Virtual Cycling',
-  'Circuit training' = 'Circuit training',
-  'Triathlon' = 'Triathlon',
-  'Alpine skiing' = 'Alpine skiing',
-  'alpine_skiing' = 'Alpine skiing',
-  'alpine_skiing_downhill' = 'Alpine skiing',
-  'AlpineSki' = 'Alpine skiing',
+  /**
+   * Triathlon
+   */
+    'Triathlon' = 'Triathlon',
+  /**
+   * Duathlon
+   */
+    'Duathlon' = 'Duathlon',
+  /**
+   * Aquathlon
+   */
+    'Aquathlon' = 'Aquathlon',
+  /**
+   * Alpine Skiing
+   * https://www.google.com/search?q=alpine+skiing+vs+downhill&oq=alpine+skiing+vs+downhill&aqs=chrome..69i57.5719j0j1&sourceid=chrome&ie=UTF-8
+   */
+  'Alpine skiing' = 'Alpine Skiing',
+  'Alpine Skiing' = 'Alpine Skiing',
+  'alpine_skiing' = 'Alpine Skiing',
+  'alpine_skiing_downhill' = 'Alpine Skiing',
+  'AlpineSki' = 'Alpine Skiing',
+  'downhill' = 'Alpine Skiing',
+  'Downhill skiing' = 'Alpine Skiing',
+  /**
+   * Crosscountry Skiing
+   * https://en.wikipedia.org/wiki/Cross-country_skiing
+   */
+  'NordicSki' = 'Nordic Skiing',
+  'Nordic skiing' = 'Nordic Skiing',
+  'Nordic Skiing' = 'Nordic Skiing',
+  'Crosscountry skiing' = 'Nordic Skiing',
+  'Crosscountry Skiing' = 'Nordic Skiing',
+  'cross_country_skiing' = 'Nordic Skiing',
+  /**
+   * Backcountry Skiing
+   * https://en.wikipedia.org/wiki/Backcountry_skiing
+   */
   'Backcountry skiing' = 'Backcountry Skiing',
   'Backcountry Skiing' = 'Backcountry Skiing',
   'BackcountrySki' = 'Backcountry Skiing',
-  'cross_country_skiing_backcountry' = 'Backcountry Skiing',
+  'cross_country_skiing_backcountry' = 'Backcountry Skiing', // @todo is this correct?
+  'backcountry' = 'Backcountry Skiing',
+  'BackCountrySki' = 'Backcountry Skiing',
+  /**
+   * Ski Touring
+   * https://en.wikipedia.org/wiki/Ski_touring
+   */
+  'Ski Touring' = 'Ski Touring',
+  /**
+   * Telemark Skiing
+   */
+  'Telemark skiing' = 'Telemark Skiing',
+  'Telemark Skiing' = 'Telemark Skiing',
+  /**
+   * Roller Skiing
+   */
+  'Roller skiing' = 'Roller Skiing',
+  'RollerSki' = 'Roller Skiing',
+  'Roller Skiing' = 'Roller Skiing',
+  /**
+   * Snowboarding
+   */
   'Snowboarding' = 'Snowboarding',
   'snowboarding' = 'Snowboarding',
   'Snowboard' = 'Snowboarding',
-  'running_street' = 'Running',
-  'running_road' = 'Running',
-  'Crosscountry skiing' = 'Crosscountry Skiing',
-  'Crosscountry Skiing' = 'Crosscountry Skiing',
-  'cross_country_skiing' = 'Crosscountry Skiing',
-  'NordicSki' = 'Nordic Skiing',
-  'Nordic Skiing' = 'Nordic Skiing',
-  'backcountry' = 'Crosscountry Skiing',
-  'BackCountrySki' = 'Crosscountry Skiing',
-  'downhill' = 'Downhill skiing',
-  'Downhill skiing' = 'Downhill skiing',
+  /**
+   * Weight training
+   */
   'Weight training' = 'Weight training',
   'WeightTraining' = 'Weight training',
+  /**
+   * Basketball
+   */
   'Basketball' = 'Basketball',
-  'Soccer' = 'Soccer',
+  /**
+   * Ice Hockey
+   */
   'Ice Hockey' = 'Ice Hockey',
+  /**
+   * Volleyball
+   */
   'Volleyball' = 'Volleyball',
+  /**
+   * Football
+   */
   'Football' = 'Football',
+  /**
+   * Softball
+   */
   'Softball' = 'Softball',
+  /**
+   * Handball
+   */
+    'Handball' = 'Handball',
+  /**
+   * Cheerleading
+   */
   'Cheerleading' = 'Cheerleading',
+  /**
+   * Baseball
+   */
   'Baseball' = 'Baseball',
+  /**
+   * Tennis
+   */
   'tennis' = 'Tennis',
   'Tennis' = 'Tennis',
+  /**
+   * Badminton
+   */
   'Badminton' = 'Badminton',
+  /**
+   * Table Tennis
+   */
   'Table tennis' = 'Table Tennis',
   'Table Tennis' = 'Table Tennis',
-  'Racquet ball' = 'Racquet ball',
+  /**
+   * Racquet ball
+   */
+  'Racquet Ball' = 'Racquet Ball',
+  'Racquet ball' = 'Racquet Ball',
+  /**
+   * Squash
+   */
   'Squash' = 'Squash',
-  'Combat sport' = 'Combat sport',
+  /**
+   * Combat sport
+   */
+  'Combat sport' = 'Combat',
+  'Combat' = 'Combat',
+  /**
+   * Boxing
+   */
   'Boxing' = 'Boxing',
+  /**
+   * Floorball
+   */
   'Floorball' = 'Floorball',
+  /**
+   * Scuba Diving
+   */
   'Scuba diving' = 'Scuba Diving',
   'Scuba Diving' = 'Scuba Diving',
+  /**
+   * Free Diving
+   */
   'Free diving' = 'Free Diving',
+  /**
+   * Diving
+   */
   'diving' = 'Diving',
   'Diving' = 'Diving',
   'diving_apnea_hunting' = 'Diving',
+  /**
+   * Snorkeling
+   */
   'Snorkeling' = 'Snorkeling',
+  /**
+   * Swimrun
+   */
   'Swimrun' = 'Swimrun',
-  'Duathlon' = 'Duathlon',
-  'Aquathlon' = 'Aquathlon',
+  /**
+   * Adventure Racing
+   */
   'Adventure Racing' = 'Adventure Racing',
+  /**
+   * Bowling
+   */
   'Bowling' = 'Bowling',
+  /**
+   * Cricket
+   */
   'Cricket' = 'Cricket',
+  /**
+   * Crosstrainer
+   */
   'Crosstrainer' = 'Crosstrainer',
+  /**
+   * Dancing
+   */
   'Dancing' = 'Dancing',
+  /**
+   * Golf
+   */
   'Golf' = 'Golf',
   'golf' = 'Golf',
+  /**
+   * Hand Gliding
+   */
   'hang_gliding' = 'Hang gliding',
   'Hang gliding' = 'Hang gliding',
+  /**
+   * Horseback Ridding
+   */
   'horseback_riding' = 'Horseback Riding',
   'Horseback Riding' = 'Horseback Riding',
+  'Horseback riding' = 'Horseback Riding',
+  /**
+   * Gymnastics
+   */
   'Gymnastics' = 'Gymnastics',
-  'Handball' = 'Handball',
-  'Horseback riding' = 'Horseback riding',
+  /**
+   * Ice Skating
+   */
   'Ice Skating' = 'Ice Skating',
   'ice_skating' = 'Ice Skating',
   'ice skating' = 'Ice Skating',
   'Ice skating' = 'Ice Skating',
   'IceSkate' = 'Ice Skating',
   'Ice Skate' = 'Ice Skating',
-  'fitness_equipment_indoor_rowing' = 'Indoor Rowing',
-  'Indoor Rowing' = 'Indoor Rowing',
-  'indoor_rowing' = 'Indoor Rowing',
+  /**
+   * Canoeing
+   */
   'Canoeing' = 'Canoeing',
+  /**
+   * Motorsports
+   */
   'Motorsports' = 'Motorsports',
+  /**
+   * Mountaineering
+   */
   'Mountaineering' = 'Mountaineering',
   'mountaineering' = 'Mountaineering',
+  /**
+   * Orienteering
+   */
   'Orienteering' = 'Orienteering',
   'running_navigate' = 'Orienteering',
+  /**
+   * Rugby
+   */
   'Rugby' = 'Rugby',
-  'Ski Touring' = 'Ski Touring',
+  /**
+   * Stretching
+   */
   'Stretching' = 'Stretching',
+  /**
+   * Strength Training
+   */
   'training_strength_training' = 'Strength Training',
   'fitness_equipment_strength_training' = 'Strength Training',
   'strength_training' = 'Strength Training',
   'Strength training' = 'Strength Training',
   'strength training' = 'Strength Training',
   'Strength Training' = 'Strength Training',
-  'Telemark skiing' = 'Telemark skiing',
+  /**
+   * Track and Field
+   */
+  'TrackAndField' = 'Track and Field',
   'Track and Field' = 'Track and Field',
-  'Trail Running' = 'Trail Running',
-  'Trail running' = 'Trail Running',
-  'trail_running' = 'Trail Running',
-  'trail' = 'Trail Running',
-  'swimming_open_water' = 'Open Water Swimming',
-  'swimming_lap_swimming' = 'Swimming',
-  'Open water swimming' = 'Open Water Swimming',
-  'open water swimming' = 'Open Water Swimming',
-  'Open Water Swimming' = 'Open Water Swimming',
-  'open_water' = 'Open Water Swimming',
-  'Nordic walking' = 'Nordic walking',
+  /**
+   * Nordic walking
+   */
+  'Nordic Walking' = 'Nordic Walking',
+  'Nordic walking' = 'Nordic Walking',
+  /**
+   * Snowshoeing
+   */
   'Snow shoeing' = 'Snowshoeing',
+  /**
+   * Windsrufing
+   */
   'Windsurfing/Surfing' = 'Windsurfing',
   'windsurfing' = 'Windsurfing',
   'Windsurfing' = 'Windsurfing',
   'Windsurf' = 'Windsurfing',
+  /**
+   * Kettlebell
+   */
   'Kettlebell' = 'Kettlebell',
-  'Roller skiing' = 'Roller skiing',
-  'RollerSki' = 'Roller skiing',
+  /**
+   * Paddling
+   */
   'paddling' = 'Paddling',
   'Paddling' = 'Paddling',
+  /**
+   * Flying
+   */
   'flying' = 'Flying',
   'Flying' = 'Flying',
-  'Cross fit' = 'Cross fit',
-  'cross_fit' = 'Cross fit',
+  /**
+   * Crossfit
+   */
+  'Cross fit' = 'Crossfit',
+  'Cross Fit' = 'Crossfit',
+  'cross_fit' = 'Crossfit',
+  'Crossfit' = 'Crossfit',
+  /**
+   * Kitesurfing
+   */
   'Kitesurfing/Kiting' = 'Kitesurfing',
   'kitesurfing' = 'Kitesurfing',
   'Kitesurfing' = 'Kitesurfing',
   'Kitesurf' = 'Kitesurfing',
+  /**
+   * Tactical
+   */
   'tactical' = 'Tactical',
   'Tactical' = 'Tactical',
+  /**
+   * Jumpmaster
+   */
   'jumpmaster' = 'Jumpmaster',
   'Jumpmaster' = 'Jumpmaster',
+  /**
+   * Boxing
+   */
   'boxing' = 'Boxing',
+  /**
+   * Floor Climbing
+   */
   'floor_climbing' = 'Floor Climbing',
   'Floor climbing' = 'Floor Climbing',
   'Floor Climbing' = 'Floor Climbing',
+  /**
+   * Paragliding
+   */
   'Paragliding' = 'Paragliding',
+  /**
+   * Treadmill
+   */
   'running_treadmill' = 'Treadmill',
   'Treadmill' = 'Treadmill',
   'treadmill' = 'Treadmill',
-  'Indoor running' = 'Indoor Running',
-  'Indoor Running' = 'Indoor Running',
-  'running_indoor' = 'Indoor Running',
-  'running_indoor_running' = 'Indoor Running',
+  /**
+   * Frisbee
+   */
   'Frisbee' = 'Frisbee',
-  'Indoor training' = 'Indoor training',
+  /**
+   * Indoor Training
+   */
+  'Indoor training' = 'Indoor Training',
+  'Indoor Training' = 'Indoor Training',
+  /**
+   * Hiking
+   */
   'Hiking' = 'Hiking',
   'hiking_trail' = 'Hiking',
   'hiking' = 'Hiking',
   'hike' = 'Hiking',
   'Hike' = 'Hiking',
+  /**
+   * Fishing
+   */
   'Fishing' = 'Fishing',
   'fishing' = 'Fishing',
+  /**
+   * Hunting
+   */
   'Hunting' = 'Hunting',
   'hunting' = 'Hunting',
+  /**
+   * Route
+   */
   'route' = 'Route',
   'Route' = 'Route',
+  /**
+   * Inline Skating
+   */
   'inline_skating' = 'Inline Skating',
   'InlineSkating' = 'Inline Skating',
   'Inline Skating' = 'Inline Skating',
   'Inline skating' = 'Inline Skating',
   'InlineSkate' = 'Inline Skating',
+  /**
+   * Rock Climbing
+   */
   'rock_climbing' = 'Rock Climbing',
   'Rock Climbing' = 'Rock Climbing',
   'Rock climbing' = 'Rock Climbing',
   'RockClimbing' = 'Rock Climbing',
+  /**
+   * Sky Diving
+   */
   'sky_diving' = 'Sky Diving',
   'Sky Diving' = 'Sky Diving',
   'Sky diving' = 'Sky Diving',
   'sky diving' = 'Sky Diving',
+  /**
+   * Snowshoeing
+   */
   'snowshoeing' = 'Snowshoeing',
   'Snowshoeing' = 'Snowshoeing',
   'Snowshoe' = 'Snowshoeing',
+  /**
+   * Snowmobiling
+   */
   'snowmobiling' = 'Snowmobiling',
   'Snowmobiling' = 'Snowmobiling',
-  'stand_up_paddleboarding' = 'Stand up paddling',
-  'Standup paddling (SUP)' = 'Stand up paddling',
-  'Stand up paddling' = 'Stand up paddling',
-  'stand up paddling' = 'Stand up paddling',
-  'Stand Up Paddling' = 'Stand up paddling',
-  'Stand up Paddling' = 'Stand up paddling',
-  'StandUpPaddling' = 'Stand up paddling',
+  /**
+   * Stand Up Paddling
+   */
+  'stand_up_paddleboarding' = 'Stand Up Paddling',
+  'Standup paddling (SUP)' = 'Stand Up Paddling',
+  'Stand up paddling' = 'Stand Up Paddling',
+  'stand up paddling' = 'Stand Up Paddling',
+  'Stand Up Paddling' = 'Stand Up Paddling',
+  'Stand up Paddling' = 'Stand Up Paddling',
+  'StandUpPaddling' = 'Stand Up Paddling',
+  /**
+   * Surfing
+   */
   'surfing' = 'Surfing',
   'Surfing' = 'Surfing',
+  /**
+   * Wakeboarding
+   */
   'wakeboarding' = 'Wakeboarding',
   'Wakeboarding' = 'Wakeboarding',
-  'water_skiing' = 'Water skiing',
-  'Water skiing' = 'Water skiing',
-  'Water Skiing' = 'Water skiing',
+  /**
+   * Water Skiing
+   */
+  'water_skiing' = 'Water Skiing',
+  'Water skiing' = 'Water Skiing',
+  'Water Skiing' = 'Water Skiing',
+  /**
+   * Flexibility Training
+   */
   'training_flexibility_training' = 'Flexibility Training',
   'flexibility_training' = 'Flexibility Training',
   'Flexibility Training' = 'Flexibility Training',
+  /**
+   * Training
+   */
   'training' = 'Training',
   'Training' = 'Training',
+  /**
+   * Cardio Training
+   */
   'cardio_training' = 'Cardio Training',
   'training_cardio_training' = 'Cardio Training',
   'Cardio Training' = 'Cardio Training',
-  'fitness_equipment_elliptical' = 'Elliptical trainer',
-  'Elliptical trainer' = 'Elliptical trainer',
-  'Elliptical' = 'Elliptical trainer',
-  'Crossfit' = 'Cross fit',
-  'Handcycle' = 'Hand cycle',
+  /**
+   * Elliptical trainer
+   */
+  'fitness_equipment_elliptical' = 'Elliptical Trainer',
+  'Elliptical trainer' = 'Elliptical Trainer',
+  'Elliptical' = 'Elliptical Trainer',
+  'EllipticalTrainer' = 'Elliptical Trainer',
+  'Elliptical Trainer' = 'Elliptical Trainer',
+  /**
+   * Hand Cycle
+   */
+  'Handcycle' = 'Hand Cycle',
+  'Hand cycle' = 'Hand Cycle',
+  'Hand Cycle' = 'Hand Cycle',
+  /**
+   * Stair Stepper
+   */
   'StairStepper' = 'Stair Stepper',
   'Stair Stepper' = 'Stair Stepper',
+  /**
+   * Velomobile
+   */
   'Velomobile' = 'Velomobile',
-  'Wheelchair' = 'Wheel chair',
-  'Wheel chair' = 'Wheel chair',
+  /**
+   * Wheel Chair
+   */
+  'Wheelchair' = 'Wheel Chair',
+  'Wheel chair' = 'Wheel Chair',
+  'Wheel Chair' = 'Wheel Chair',
   'Workout' = 'Workout',
 }
 

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -362,7 +362,7 @@ export class StravaGPXTypeMapping {
 
   public static readonly map: Array<{ id: number, type: string }> = [
     {id: 1, type: ActivityTypes.Cycling},
-    {id: 2, type: ActivityTypes.AlpineSKi},
+    {id: 2, type: ActivityTypes.AlpineSki},
     {id: 3, type: ActivityTypes.BackCountrySki},
     {id: 4, type: ActivityTypes.Hiking},
     {id: 5, type: ActivityTypes.IceSkate},

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -819,7 +819,7 @@ export enum ActivityTypeGroups {
 }
 
 export class ActivityTypesGroupMapping {
-  public static readonly map: { [type: string]: ActivityTypes[] } = {
+  public static readonly map: { [key in ActivityTypeGroups]: ActivityTypes[] } = {
     [ActivityTypeGroups.Running]: [
       ActivityTypes.Running,
       ActivityTypes.TrailRunning,

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -5,12 +5,26 @@ import {DataPace} from '../data/data.pace';
 import {DataSpeed} from '../data/data.speed';
 import {DataSwimPace} from '../data/data.swim-pace';
 import {DataVerticalSpeedAvg} from '../data/data.vertical-speed-avg';
-import {type} from 'os';
 
 export class ActivityTypesHelper {
   static getActivityTypesAsUniqueArray(): string[] {
     return Array.from(new Set(Object.keys(ActivityTypes).reduce((array: string[], key: string) => {
       array.push(ActivityTypes[<keyof typeof ActivityTypes>key]); // Important get the key via the enum else it will be chaos
+      return array;
+    }, []))).sort((left, right) => {
+      if (left < right) {
+        return -1;
+      }
+      if (left > right) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+
+  static getActivityTypeGroupsAsUniqueArray(): string[] {
+    return Array.from(new Set(Object.keys(ActivityTypeGroups).reduce((array: string[], key: string) => {
+      array.push(ActivityTypeGroups[<keyof typeof ActivityTypeGroups>key]); // Important get the key via the enum else it will be chaos
       return array;
     }, []))).sort((left, right) => {
       if (left < right) {
@@ -56,6 +70,17 @@ export class ActivityTypesHelper {
         return [DataSpeed.type];
     }
   }
+
+  /**
+   * Get's back the activity group an activity belongs to or returns unspecified activity group
+   * @param activityType
+   */
+  static getActivityGroupForActivityType(activityType: ActivityTypes): ActivityTypeGroups {
+    return ActivityTypeGroups[<keyof typeof ActivityTypeGroups>ActivityTypesHelper.getActivityTypeGroupsAsUniqueArray().find(activityTypeGroupString => {
+      return ActivityTypesGroupMapping.map[<keyof typeof ActivityTypeGroups>activityTypeGroupString].find(groupItem => groupItem === activityType)
+    }) || ActivityTypeGroups.Unspecified];
+  }
+
 }
 
 /**
@@ -788,7 +813,7 @@ export enum ActivityTypeGroups {
   'Water Sports' = 'Water Sports',
   'WaterSports' = 'Water Sports',
   'Diving' = 'Diving',
-  'Team racket' = 'Team Racket',
+  'Team Racket' = 'Team Racket',
   'TeamRacket' = 'Team Racket',
   'Unspecified' = 'Unspecified',
 }
@@ -855,6 +880,7 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.OpenWaterSwimming,
       ActivityTypes.Surfing,
       ActivityTypes.Kitesurfing,
+      ActivityTypes.Wakeboarding,
       // @todo add more
     ],
     [ActivityTypeGroups.Diving]: [
@@ -864,8 +890,9 @@ export class ActivityTypesGroupMapping {
     ],
     [ActivityTypeGroups.TeamRacket]: [
       ActivityTypes.Golf,
-      ActivityTypes.Soccer,
+      // ActivityTypes.Soccer,
       ActivityTypes.AmericanFootball,
+      ActivityTypes.Football,
       ActivityTypes.Badminton,
       ActivityTypes.Baseball,
       ActivityTypes.Basketball,
@@ -879,9 +906,10 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.TableTennis,
       ActivityTypes.Tennis,
       // @todo add more
+    ],
+    [ActivityTypeGroups.Unspecified]: [
     ]
   };
-
 }
 
 export class StravaGPXTypeMapping {

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -5,6 +5,7 @@ import {DataPace} from '../data/data.pace';
 import {DataSpeed} from '../data/data.speed';
 import {DataSwimPace} from '../data/data.swim-pace';
 import {DataVerticalSpeedAvg} from '../data/data.vertical-speed-avg';
+import {type} from 'os';
 
 export class ActivityTypesHelper {
   static getActivityTypesAsUniqueArray(): string[] {
@@ -107,6 +108,7 @@ export enum ActivityTypes {
   'VirtualRun' = 'Virtual Running',
   'Virtual running' = 'Virtual Running',
   'Virtual Running' = 'Virtual Running',
+  'VirtualRunning' = 'Virtual Running',
   /**
    * Running
    */
@@ -131,6 +133,7 @@ export enum ActivityTypes {
    */
   'Indoor running' = 'Indoor Running',
   'Indoor Running' = 'Indoor Running',
+  'IndoorRunning' = 'Indoor Running',
   'running_indoor' = 'Indoor Running',
   'running_indoor_running' = 'Indoor Running',
   /**
@@ -148,23 +151,26 @@ export enum ActivityTypes {
   /**
    * Indoor Cycling
    */
-    'cycling_indoor_cycling' = 'Indoor Cycling',
+  'cycling_indoor_cycling' = 'Indoor Cycling',
   'Indoorcycling' = 'Indoor Cycling',
   'indoor_cycling' = 'Indoor Cycling',
   'Indoor cycling' = 'Indoor Cycling',
+  'IndoorCycling' = 'Indoor Cycling',
   'Indoor Cycling' = 'Indoor Cycling',
   /**
    * Virtual Cycling
    */
-    'cycling_virtual_activity' = 'Virtual Cycling',
+  'cycling_virtual_activity' = 'Virtual Cycling',
   'VirtualRide' = 'Virtual Cycling',
   'Virtual Cycling' = 'Virtual Cycling',
-  'Circuit training' = 'Circuit training',
+  'VirtualCycling' = 'Virtual Cycling',
+
   /**
    * E-Biking
    */
   'e_biking' = 'E-Biking',
   'E Biking' = 'E-Biking',
+  'EBiking' = 'E-Biking',
   'E biking' = 'E-Biking',
   'EBikeRide' = 'E-Biking',
   'E-Biking' = 'E-Biking',
@@ -192,6 +198,10 @@ export enum ActivityTypes {
    */
   'driving' = 'Driving',
   'Driving' = 'Driving',
+  /**
+   * Circuit training
+   */
+  'Circuit training' = 'Circuit training',
   /**
    * Swimming
    */
@@ -224,6 +234,7 @@ export enum ActivityTypes {
   'american_football' = 'American Football',
   'American footBall' = 'American Football',
   'American Football' = 'American Football',
+  'AmericanFootball' = 'American Football',
   /**
    * Skating
    */
@@ -275,6 +286,7 @@ export enum ActivityTypes {
    * Indoor Rowing
    */
     'fitness_equipment_indoor_rowing' = 'Indoor Rowing',
+  'IndoorRowing' = 'Indoor Rowing',
   'Indoor Rowing' = 'Indoor Rowing',
   'indoor_rowing' = 'Indoor Rowing',
   /**
@@ -299,6 +311,7 @@ export enum ActivityTypes {
    */
   'Alpine skiing' = 'Alpine Skiing',
   'Alpine Skiing' = 'Alpine Skiing',
+  'AlpineSkiing' = 'Alpine Skiing',
   'alpine_skiing' = 'Alpine Skiing',
   'alpine_skiing_downhill' = 'Alpine Skiing',
   'AlpineSki' = 'Alpine Skiing',
@@ -313,6 +326,8 @@ export enum ActivityTypes {
   'Nordic Skiing' = 'Nordic Skiing',
   'Crosscountry skiing' = 'Nordic Skiing',
   'Crosscountry Skiing' = 'Nordic Skiing',
+  'CrosscountrySkiing' = 'Nordic Skiing',
+  'CrossCountrySkiing' = 'Nordic Skiing',
   'cross_country_skiing' = 'Nordic Skiing',
   /**
    * Backcountry Skiing
@@ -320,6 +335,8 @@ export enum ActivityTypes {
    */
   'Backcountry skiing' = 'Backcountry Skiing',
   'Backcountry Skiing' = 'Backcountry Skiing',
+  'BackCountrySkiing' = 'Backcountry Skiing',
+  'BackcountrySkiing' = 'Backcountry Skiing',
   'BackcountrySki' = 'Backcountry Skiing',
   'cross_country_skiing_backcountry' = 'Backcountry Skiing', // @todo is this correct?
   'backcountry' = 'Backcountry Skiing',
@@ -329,10 +346,12 @@ export enum ActivityTypes {
    * https://en.wikipedia.org/wiki/Ski_touring
    */
   'Ski Touring' = 'Ski Touring',
+  'SkiTouring' = 'Ski Touring',
   /**
    * Telemark Skiing
    */
   'Telemark skiing' = 'Telemark Skiing',
+  'TelemarkSkiing' = 'Telemark Skiing',
   'Telemark Skiing' = 'Telemark Skiing',
   /**
    * Roller Skiing
@@ -359,6 +378,7 @@ export enum ActivityTypes {
    * Ice Hockey
    */
   'Ice Hockey' = 'Ice Hockey',
+  'IceHockey' = 'Ice Hockey',
   /**
    * Volleyball
    */
@@ -397,10 +417,14 @@ export enum ActivityTypes {
    */
   'Table tennis' = 'Table Tennis',
   'Table Tennis' = 'Table Tennis',
+  'TableTennis' = 'Table Tennis',
   /**
-   * Racquet ball
+   * Racquet Ball
    */
+  'racket' = 'Racquet Ball',
+  'racquet_ball' = 'Racquet Ball',
   'Racquet Ball' = 'Racquet Ball',
+  'RacquetBall' = 'Racquet Ball',
   'Racquet ball' = 'Racquet Ball',
   /**
    * Squash
@@ -424,10 +448,13 @@ export enum ActivityTypes {
    */
   'Scuba diving' = 'Scuba Diving',
   'Scuba Diving' = 'Scuba Diving',
+  'ScubaDiving' = 'Scuba Diving',
   /**
    * Free Diving
    */
   'Free diving' = 'Free Diving',
+  'Free Diving' = 'Free Diving',
+  'FreeDiving' = 'Free Diving',
   /**
    * Diving
    */
@@ -477,6 +504,7 @@ export enum ActivityTypes {
    */
   'horseback_riding' = 'Horseback Riding',
   'Horseback Riding' = 'Horseback Riding',
+  'HorsebackRiding' = 'Horseback Riding',
   'Horseback riding' = 'Horseback Riding',
   /**
    * Gymnastics
@@ -486,6 +514,7 @@ export enum ActivityTypes {
    * Ice Skating
    */
   'Ice Skating' = 'Ice Skating',
+  'IceSkating' = 'Ice Skating',
   'ice_skating' = 'Ice Skating',
   'ice skating' = 'Ice Skating',
   'Ice skating' = 'Ice Skating',
@@ -534,6 +563,7 @@ export enum ActivityTypes {
   /**
    * Nordic walking
    */
+  'NordicWalking' = 'Nordic Walking',
   'Nordic Walking' = 'Nordic Walking',
   'Nordic walking' = 'Nordic Walking',
   /**
@@ -750,12 +780,107 @@ export enum ActivityTypeGroups {
   'Cycling' = 'Cycling',
   'Performance' = 'Performance',
   'Indoor Sports' = 'Indoor Sports',
+  'IndoorSports' = 'Indoor Sports',
   'Outdoor Adventures' = 'Outdoor Adventures',
+  'OutdoorAdventures' = 'Outdoor Adventures',
   'Winter Sports' = 'Winter Sports',
+  'WinterSports' = 'Winter Sports',
   'Water Sports' = 'Water Sports',
+  'WaterSports' = 'Water Sports',
   'Diving' = 'Diving',
   'Team racket' = 'Team Racket',
+  'TeamRacket' = 'Team Racket',
   'Unspecified' = 'Unspecified',
+}
+
+export class ActivityTypesGroupMapping {
+  public static readonly map: { [type: string]: ActivityTypes[] } = {
+    [ActivityTypeGroups.Running]: [
+      ActivityTypes.Running,
+      ActivityTypes.TrailRunning,
+      ActivityTypes.Treadmill,
+      ActivityTypes.IndoorRunning,
+      ActivityTypes.VirtualRunning,
+      // @todo add more
+    ],
+    [ActivityTypeGroups.Cycling]: [
+      ActivityTypes.Cycling,
+      ActivityTypes.IndoorCycling,
+      ActivityTypes.MountainBiking,
+      ActivityTypes.Biking,
+      ActivityTypes.VirtualCycling,
+      ActivityTypes.EBiking,
+      // @todo add more
+    ],
+    [ActivityTypeGroups.Performance]: [
+      ActivityTypes.Crossfit,
+      ActivityTypes.Orienteering,
+      ActivityTypes.RollerSki,
+      ActivityTypes.TrackAndField,
+      // @todo add more
+    ],
+    [ActivityTypeGroups.IndoorSports]: [
+      ActivityTypes.Gymnastics,
+      ActivityTypes.Yoga,
+      ActivityTypes.Stretching,
+      ActivityTypes.Kettlebell,
+      ActivityTypes.IndoorRowing,
+      ActivityTypes.Floorball,
+      ActivityTypes.Dancing,
+      ActivityTypes.Crosstrainer,
+      // @todo add more
+    ],
+    [ActivityTypeGroups.OutdoorAdventures]: [
+      ActivityTypes.Walking,
+      ActivityTypes.Hiking,
+      ActivityTypes.NordicWalking,
+      ActivityTypes.HorsebackRiding,
+      ActivityTypes.Climbing,
+      // @todo add more
+    ],
+    [ActivityTypeGroups.WinterSports]: [
+      ActivityTypes.CrosscountrySkiing,
+      ActivityTypes.BackCountrySkiing,
+      ActivityTypes.AlpineSkiing,
+      ActivityTypes.TelemarkSkiing,
+      ActivityTypes.Snowboarding,
+      ActivityTypes.Snowshoeing,
+      ActivityTypes.SkiTouring,
+      ActivityTypes.IceSkating,
+      // @todo add more
+    ],
+    [ActivityTypeGroups.WaterSports]: [
+      ActivityTypes.Rowing,
+      ActivityTypes.Swimming,
+      ActivityTypes.OpenWaterSwimming,
+      ActivityTypes.Surfing,
+      ActivityTypes.Kitesurfing,
+      // @todo add more
+    ],
+    [ActivityTypeGroups.Diving]: [
+      ActivityTypes.Diving,
+      ActivityTypes.ScubaDiving,
+      ActivityTypes.FreeDiving,
+    ],
+    [ActivityTypeGroups.TeamRacket]: [
+      ActivityTypes.Golf,
+      ActivityTypes.Soccer,
+      ActivityTypes.AmericanFootball,
+      ActivityTypes.Badminton,
+      ActivityTypes.Baseball,
+      ActivityTypes.Basketball,
+      ActivityTypes.Bowling,
+      ActivityTypes.Handball,
+      ActivityTypes.IceHockey,
+      ActivityTypes.Rugby,
+      ActivityTypes.Softball,
+      ActivityTypes.Squash,
+      ActivityTypes.RacquetBall,
+      ActivityTypes.TableTennis,
+      ActivityTypes.Tennis,
+    ]
+  };
+
 }
 
 export class StravaGPXTypeMapping {

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -61,9 +61,9 @@ export class ActivityTypesHelper {
  * This enum works like a all matchers for normalized sport types between different naming across services
  *
  * It helps as you can call request an activity type with different namin eg .BackCountrySki or .BackCountrySkiing and get a uniform value
- * Also helps in case you have peristed data that do not match or have been peristed wrongly
+ * Also helps in case you have persited data that do not match or have been peristed wrongly
  *
- * Important: don't forget to decalare the original string value aka: 'Running' = 'Running'
+ * Important: don't forget to declare the original string value aka: 'Running' = 'Running'
  *
  * @todo how do we write activity names? Is it Alpine skiing? or Alpine Skiing? For now I used uppercase each word
  */

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -74,10 +74,11 @@ export class ActivityTypesHelper {
   /**
    * Get's back the activity group an activity belongs to or returns unspecified activity group
    * @param activityType
+   * This function can also be called: Fighting with a non functional language
    */
   static getActivityGroupForActivityType(activityType: ActivityTypes): ActivityTypeGroups {
     return ActivityTypeGroups[<keyof typeof ActivityTypeGroups>ActivityTypesHelper.getActivityTypeGroupsAsUniqueArray().find(activityTypeGroupString => { // Could also iterate over the map
-      return ActivityTypesGroupMapping.map[<keyof typeof ActivityTypeGroups>activityTypeGroupString].find(groupItem => groupItem === activityType)
+      return ActivityTypesGroupMapping.map[ActivityTypeGroups[<keyof typeof ActivityTypeGroups>activityTypeGroupString]].find((groupItem: ActivityTypes) => groupItem === activityType)
     }) || ActivityTypeGroups.Unspecified];
   }
 
@@ -102,7 +103,10 @@ export enum ActivityTypes {
   'Unknown Sport' = 'Unknown Sport',
   'undefined' = 'Unknown Sport',
   'Not specified sport' = 'Unknown Sport',
-  'Other' = 'Unknown Sport', // @todo is this correct?
+  /**
+   * Other
+   */
+  'Other' = 'Other',
   /**
    * Generic
    */
@@ -580,6 +584,7 @@ export enum ActivityTypes {
   'Strength training' = 'Strength Training',
   'strength training' = 'Strength Training',
   'Strength Training' = 'Strength Training',
+  'StrengthTraining' = 'Strength Training',
   /**
    * Track and Field
    */
@@ -757,6 +762,7 @@ export enum ActivityTypes {
   'training_flexibility_training' = 'Flexibility Training',
   'flexibility_training' = 'Flexibility Training',
   'Flexibility Training' = 'Flexibility Training',
+  'FlexibilityTraining' = 'Flexibility Training',
   /**
    * Training
    */
@@ -842,6 +848,8 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.Orienteering,
       ActivityTypes.RollerSki,
       ActivityTypes.TrackAndField,
+      ActivityTypes.Triathlon,
+      ActivityTypes.Multisport,
       // @todo add more
     ],
     [ActivityTypeGroups.IndoorSports]: [
@@ -853,6 +861,10 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.Floorball,
       ActivityTypes.Dancing,
       ActivityTypes.Crosstrainer,
+      ActivityTypes.WeightTraining,
+      ActivityTypes.StrengthTraining,
+      ActivityTypes.Training,
+      ActivityTypes.FlexibilityTraining,
       // @todo add more
     ],
     [ActivityTypeGroups.OutdoorAdventures]: [
@@ -861,6 +873,7 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.NordicWalking,
       ActivityTypes.HorsebackRiding,
       ActivityTypes.Climbing,
+      ActivityTypes.RockClimbing,
       // @todo add more
     ],
     [ActivityTypeGroups.WinterSports]: [
@@ -881,6 +894,7 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.Surfing,
       ActivityTypes.Kitesurfing,
       ActivityTypes.Wakeboarding,
+      ActivityTypes.Sailing,
       // @todo add more
     ],
     [ActivityTypeGroups.Diving]: [

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -156,7 +156,6 @@ export enum ActivityTypes {
   'Trail Running' = 'Trail Running',
   'Trail running' = 'Trail Running',
   'trail_running' = 'Trail Running',
-  'trail' = 'Trail Running', // @todo hack?
   /**
    * Indoor Running
    */

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -1,10 +1,10 @@
-import {DataSpeedAvg} from '../data/data.speed-avg';
-import {DataPaceAvg} from '../data/data.pace-avg';
-import {DataSwimPaceAvg} from '../data/data.swim-pace-avg';
-import {DataPace} from '../data/data.pace';
-import {DataSpeed} from '../data/data.speed';
-import {DataSwimPace} from '../data/data.swim-pace';
-import {DataVerticalSpeedAvg} from '../data/data.vertical-speed-avg';
+import { DataSpeedAvg } from '../data/data.speed-avg';
+import { DataPaceAvg } from '../data/data.pace-avg';
+import { DataSwimPaceAvg } from '../data/data.swim-pace-avg';
+import { DataPace } from '../data/data.pace';
+import { DataSpeed } from '../data/data.speed';
+import { DataSwimPace } from '../data/data.swim-pace';
+import { DataVerticalSpeedAvg } from '../data/data.vertical-speed-avg';
 
 export class ActivityTypesHelper {
   static getActivityTypesAsUniqueArray(): string[] {

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -229,7 +229,7 @@ export enum ActivityTypes {
   /**
    * Circuit training
    */
-  'Circuit training' = 'Circuit training',
+  'Circuit training' = 'Circuit Training',
   /**
    * Swimming
    */
@@ -396,8 +396,8 @@ export enum ActivityTypes {
   /**
    * Weight training
    */
-  'Weight training' = 'Weight training',
-  'WeightTraining' = 'Weight training',
+  'Weight training' = 'Weight Training',
+  'WeightTraining' = 'Weight Training',
   /**
    * Basketball
    */
@@ -525,8 +525,8 @@ export enum ActivityTypes {
   /**
    * Hand Gliding
    */
-  'hang_gliding' = 'Hang gliding',
-  'Hang gliding' = 'Hang gliding',
+  'hang_gliding' = 'Hang Gliding',
+  'Hang gliding' = 'Hang Gliding',
   /**
    * Horseback Ridding
    */

--- a/src/activities/activityt-types.spec.ts
+++ b/src/activities/activityt-types.spec.ts
@@ -1,0 +1,23 @@
+import {ActivityInterface} from './activity.interface';
+import {ActivityTypeGroups, ActivityTypes, ActivityTypesHelper} from './activity.types';
+
+describe('ActivityTypes', () => {
+
+  beforeEach(() => {
+
+  });
+
+  it('get the correct activity group', () => {
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Running)).toBe(ActivityTypeGroups.Running);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Cycling)).toBe(ActivityTypeGroups.Cycling);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Crossfit)).toBe(ActivityTypeGroups.Performance);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.IndoorRowing)).toBe(ActivityTypeGroups.IndoorSports);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Climbing)).toBe(ActivityTypeGroups.OutdoorAdventures);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.AlpineSkiing)).toBe(ActivityTypeGroups.WinterSports);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Wakeboarding)).toBe(ActivityTypeGroups.WaterSports);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Diving)).toBe(ActivityTypeGroups.Diving);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Tennis)).toBe(ActivityTypeGroups.TeamRacket);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Workout)).toBe(ActivityTypeGroups.Unspecified);
+  });
+
+});

--- a/src/activities/activityt-types.spec.ts
+++ b/src/activities/activityt-types.spec.ts
@@ -1,5 +1,4 @@
-import {ActivityInterface} from './activity.interface';
-import {ActivityTypeGroups, ActivityTypes, ActivityTypesHelper} from './activity.types';
+import { ActivityTypeGroups, ActivityTypes, ActivityTypesHelper } from './activity.types';
 
 describe('ActivityTypes', () => {
 


### PR DESCRIPTION
The ultimate purpose of this PR is to group activities in order for consuming projects to be able to apply eg coloring by "outdoor" activities. 

I am opening from now the PR just to debate on a few things, since it does contain some big refactoring. 

I added some @todo points that explain / ask a few this time ;-) 

I would though to explain the Activity types enum. 

The `ActivityTypes` enum has many different keys that point to the same value. That is in order to access fast and catch as many "typos" different input and produce one uniformal value. I added that to a small doc block above each "match" group.  This also allows flexibility on accessing values code wise.  Eg `ActivityTypes.TrailRunning` is more nice to have in code than `ActivityTypes['Trail Running']` so a key of `TrailRunning` could be added to the enum. 

Now this is what I think but if you have a better approach i'd be happy to refactor more. 