### PR TITLE
Add isTrainer and hasPowerMeter to activity interface

### DIFF
--- a/integrationTests/activities-parsing.integration.spec.ts
+++ b/integrationTests/activities-parsing.integration.spec.ts
@@ -38,6 +38,8 @@ describe('Integration tests with native & custom dom parser', () => {
         // Then
         eventInterfacePromise.then((event: EventInterface) => {
           expect(event.getFirstActivity().type).toEqual(ActivityTypes.cycling);
+          expect(event.getFirstActivity().hasPowerMeter()).toEqual(false);
+          expect(event.getFirstActivity().isTrainer()).toEqual(false);
           expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
             .toEqual(expectedSamplesLength);
           expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);
@@ -115,6 +117,8 @@ describe('Integration tests with native & custom dom parser', () => {
           // Then
           eventInterfacePromise.then((event: EventInterface) => {
             expect(event.getFirstActivity().type).toEqual(ActivityTypes.cycling);
+            expect(event.getFirstActivity().hasPowerMeter()).toEqual(false);
+            expect(event.getFirstActivity().isTrainer()).toEqual(false);
             expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
               .toEqual(expectedSamplesLength);
             expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);
@@ -151,6 +155,8 @@ describe('Integration tests with native & custom dom parser', () => {
             expect(event.getFirstActivity().type).toEqual(ActivityTypes.cycling);
             expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
               .toEqual(expectedSamplesLength);
+            expect(event.getFirstActivity().hasPowerMeter()).toEqual(false);
+            expect(event.getFirstActivity().isTrainer()).toEqual(false);
             expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);
             expect(event.getFirstActivity().getSquashedStreamData(DataLatitudeDegrees.type).length).toEqual(expectedSamplesLength);
             expect(event.getFirstActivity().getSquashedStreamData(DataDistance.type).length).toEqual(expectedSamplesLength);
@@ -186,6 +192,8 @@ describe('Integration tests with native & custom dom parser', () => {
           expect(event.getFirstActivity().type).toEqual(ActivityTypes.cycling);
           expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
             .toEqual(expectedSamplesLength);
+          expect(event.getFirstActivity().hasPowerMeter()).toEqual(false);
+          expect(event.getFirstActivity().isTrainer()).toEqual(false);
           expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);
           expect(event.getFirstActivity().getSquashedStreamData(DataLatitudeDegrees.type).length).toEqual(expectedSamplesLength);
           expect(event.getFirstActivity().getSquashedStreamData(DataDistance.type).length).toEqual(expectedSamplesLength);
@@ -224,6 +232,8 @@ describe('Integration tests with native & custom dom parser', () => {
           expect(event.getFirstActivity().type).toEqual(ActivityTypes.run);
           expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
             .toEqual(expectedSamplesLength);
+          expect(event.getFirstActivity().hasPowerMeter()).toEqual(false);
+          expect(event.getFirstActivity().isTrainer()).toEqual(false);
           expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);
           expect(event.getFirstActivity().getSquashedStreamData(DataLatitudeDegrees.type).length).toEqual(expectedSamplesLength);
           expect(event.getFirstActivity().getSquashedStreamData(DataDistance.type).length).toEqual(expectedSamplesLength);
@@ -261,6 +271,8 @@ describe('Integration tests with native & custom dom parser', () => {
             expect(event.getFirstActivity().type).toEqual(ActivityTypes.run);
             expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
               .toEqual(expectedSamplesLength);
+            expect(event.getFirstActivity().hasPowerMeter()).toEqual(false);
+            expect(event.getFirstActivity().isTrainer()).toEqual(false);
             expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);
             expect(event.getFirstActivity().getSquashedStreamData(DataLatitudeDegrees.type).length).toEqual(expectedSamplesLength);
             expect(event.getFirstActivity().getSquashedStreamData(DataDistance.type).length).toEqual(expectedSamplesLength);
@@ -292,7 +304,9 @@ describe('Integration tests with native & custom dom parser', () => {
 
           // Then
           eventInterfacePromise.then((event: EventInterface) => {
-            expect(event.getFirstActivity().type).toEqual(ActivityTypes.cycling_virtual_activity);
+            expect(event.getFirstActivity().type).toEqual(ActivityTypes.VirtualRide);
+            expect(event.getFirstActivity().hasPowerMeter()).toEqual(true);
+            expect(event.getFirstActivity().isTrainer()).toEqual(true);
             expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
               .toEqual(expectedSamplesLength);
             expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);
@@ -592,6 +606,8 @@ describe('Integration tests with native & custom dom parser', () => {
           // Then
           eventInterfacePromise.then((event: EventInterface) => {
             expect(event.getFirstActivity().type).toEqual(ActivityTypes.cycling_virtual_activity);
+            expect(event.getFirstActivity().hasPowerMeter()).toEqual(true);
+            expect(event.getFirstActivity().isTrainer()).toEqual(true);
             expect(event.getFirstActivity().getStream(DataDistance.type).getDurationOfData(true, true).length)
               .toEqual(expectedSamplesLength);
             expect(event.getFirstActivity().getSquashedStreamData(DataLongitudeDegrees.type).length).toEqual(expectedSamplesLength);

--- a/src/activities/activity.interface.ts
+++ b/src/activities/activity.interface.ts
@@ -19,6 +19,10 @@ export interface ActivityInterface extends StatsClassInterface, DurationClassInt
 
   hasPositionData(startDate?: Date, endDate?: Date): boolean;
 
+  isTrainer(): boolean;
+
+  hasPowerMeter(): boolean;
+
   getStreamData(streamType: string | StreamInterface, startDate?: Date, endDate?: Date): (number | null)[];
 
   getSquashedStreamData(streamType: string, startDate?: Date, endDate?: Date): number[];

--- a/src/activities/activity.spec.ts
+++ b/src/activities/activity.spec.ts
@@ -129,4 +129,146 @@ describe('Activity', () => {
     });
   });
 
+  describe('Trainer flagging', () => {
+
+    it('should flag activities to be performed on a trainer', () => {
+
+      // Given
+      const types = [
+        ActivityTypes.VirtualRun,
+        ActivityTypes.VirtualCycling,
+        ActivityTypes.Treadmill,
+        ActivityTypes.IndoorCycling,
+        ActivityTypes.IndoorRunning,
+        ActivityTypes.IndoorRowing,
+        ActivityTypes.Crosstrainer,
+        ActivityTypes.EllipticalTrainer,
+        ActivityTypes.FitnessEquipment,
+        ActivityTypes.StairStepper,
+      ];
+
+      // When, Then
+      types.forEach(type => {
+        const fakeActivity = new Activity(new Date(), new Date(), type, new Creator('John doo'));
+        expect(fakeActivity.isTrainer()).toBeTruthy();
+      })
+
+    });
+
+    it('should NOT flag activities to be performed on a trainer', () => {
+
+      // Given
+      const types = [
+        ActivityTypes.Aerobics,
+        ActivityTypes.AlpineSkiing,
+        ActivityTypes.AmericanFootball,
+        ActivityTypes.Aquathlon,
+        ActivityTypes.BackcountrySkiing,
+        ActivityTypes.Badminton,
+        ActivityTypes.Baseball,
+        ActivityTypes.Basketball,
+        ActivityTypes.Boxing,
+        ActivityTypes.Canoeing,
+        ActivityTypes.CardioTraining,
+        ActivityTypes.Climbing,
+        ActivityTypes.Combat,
+        ActivityTypes.Cricket,
+        ActivityTypes.Crossfit,
+        ActivityTypes.CrosscountrySkiing,
+        ActivityTypes.Cycling,
+        ActivityTypes.Dancing,
+        ActivityTypes.Diving,
+        ActivityTypes.DownhillSkiing,
+        ActivityTypes.Driving,
+        ActivityTypes.Duathlon,
+        ActivityTypes.EBikeRide,
+        ActivityTypes.Fishing,
+        ActivityTypes.FlexibilityTraining,
+        ActivityTypes.FloorClimbing,
+        ActivityTypes.Floorball,
+        ActivityTypes.Flying,
+        ActivityTypes.Football,
+        ActivityTypes.FreeDiving,
+        ActivityTypes.Frisbee,
+        ActivityTypes.Generic,
+        ActivityTypes.Golf,
+        ActivityTypes.Gymnastics,
+        ActivityTypes.Handcycle,
+        ActivityTypes.Handball,
+        ActivityTypes.HangGliding,
+        ActivityTypes.Hiking,
+        ActivityTypes.HorsebackRiding,
+        ActivityTypes.IceHockey,
+        ActivityTypes.IceSkating,
+        ActivityTypes.IndoorTraining,
+        ActivityTypes.InlineSkating,
+        ActivityTypes.Kayaking,
+        ActivityTypes.Kettlebell,
+        ActivityTypes.Kitesurfing,
+        ActivityTypes.Motorcycling,
+        ActivityTypes.Motorsports,
+        ActivityTypes.MountainBiking,
+        ActivityTypes.Mountaineering,
+        ActivityTypes.NordicWalking,
+        ActivityTypes.OpenWaterSwimming,
+        ActivityTypes.Orienteering,
+        ActivityTypes.Paddling,
+        ActivityTypes.Paragliding,
+        ActivityTypes.Rafting,
+        ActivityTypes.RockClimbing,
+        ActivityTypes.RollerSki,
+        ActivityTypes.Rowing,
+        ActivityTypes.Rugby,
+        ActivityTypes.Running,
+        ActivityTypes.Sailing,
+        ActivityTypes.ScubaDiving,
+        ActivityTypes.Skating,
+        ActivityTypes.SkiTouring,
+        ActivityTypes.SkyDiving,
+        ActivityTypes.Snorkeling,
+        ActivityTypes.Snowboarding,
+        ActivityTypes.Snowmobiling,
+        ActivityTypes.Snowshoeing,
+        ActivityTypes.Soccer,
+        ActivityTypes.Softball,
+        ActivityTypes.Squash,
+        ActivityTypes.StandUpPaddling,
+        ActivityTypes.StrengthTraining,
+        ActivityTypes.Stretching,
+        ActivityTypes.Surfing,
+        ActivityTypes.Swimming,
+        ActivityTypes.Swimrun,
+        ActivityTypes.TableTennis,
+        ActivityTypes.Tactical,
+        ActivityTypes.TelemarkSkiing,
+        ActivityTypes.Tennis,
+        ActivityTypes.TrackAndField,
+        ActivityTypes.TrailRunning,
+        ActivityTypes.Training,
+        ActivityTypes.Trekking,
+        ActivityTypes.Triathlon,
+        ActivityTypes.UnknownSport,
+        ActivityTypes.Velomobile,
+        ActivityTypes.Volleyball,
+        ActivityTypes.Wakeboarding,
+        ActivityTypes.Walking,
+        ActivityTypes.WaterSkiing,
+        ActivityTypes.WeightTraining,
+        ActivityTypes.Wheelchair,
+        ActivityTypes.Windsurfing,
+        ActivityTypes.Workout,
+        ActivityTypes.Yoga,
+        ActivityTypes.YogaPilates,
+      ];
+
+      // When, Then
+      types.forEach(type => {
+        const fakeActivity = new Activity(new Date(), new Date(), type, new Creator('John doo'));
+        expect(fakeActivity.isTrainer()).toBeFalsy();
+      })
+
+    });
+
+  });
+
 });

--- a/src/activities/activity.ts
+++ b/src/activities/activity.ts
@@ -16,8 +16,13 @@ import { IntensityZonesJSONInterface } from '../intensity-zones/intensity-zones.
 import { isNumber } from '../events/utilities/helpers';
 import { EventUtilities } from '../events/utilities/event.utilities';
 import { DataGNSSDistance } from '../data/data.gnss-distance';
+import { DataPower } from '../data/data.power';
 
 export class Activity extends DurationClassAbstract implements ActivityInterface {
+
+  private static readonly TRAINER_TYPES: ActivityTypes[] = [ActivityTypes.VirtualRun, ActivityTypes.VirtualCycling, ActivityTypes.Treadmill,
+    ActivityTypes.IndoorCycling, ActivityTypes.IndoorRunning, ActivityTypes.IndoorRowing, ActivityTypes.Crosstrainer, ActivityTypes.EllipticalTrainer, ActivityTypes.FitnessEquipment, ActivityTypes.StairStepper,];
+
   public type: ActivityTypes;
   public creator: CreatorInterface;
   public intensityZones: IntensityZonesInterface[] = []; // maybe rename
@@ -63,7 +68,7 @@ export class Activity extends DurationClassAbstract implements ActivityInterface
   }
 
   removeStream(stream: StreamInterface): this {
-    this.streams = this.streams.filter((activityStream) => stream !== activityStream)
+    this.streams = this.streams.filter((activityStream) => stream !== activityStream);
     return this;
   }
 
@@ -91,7 +96,16 @@ export class Activity extends DurationClassAbstract implements ActivityInterface
   }
 
   hasPositionData(startDate?: Date, endDate?: Date): boolean {
-    return this.hasStreamData(DataLatitudeDegrees.type, startDate, endDate) && this.hasStreamData(DataLongitudeDegrees.type, startDate, endDate);
+    return this.hasStreamData(DataLatitudeDegrees.type, startDate, endDate)
+      && this.hasStreamData(DataLongitudeDegrees.type, startDate, endDate);
+  }
+
+  isTrainer(): boolean {
+    return Activity.TRAINER_TYPES.indexOf(this.type) !== -1;
+  }
+
+  hasPowerMeter(): boolean {
+    return this.hasStreamData(DataPower.type);
   }
 
   getStream(streamType: string): StreamInterface {


### PR DESCRIPTION
This PR adds ability to know if:

- An activity has been performed on a trainer: Usually everything performed with a fitness equipment, or anything virtual.

- An activity has been performed with a power meter (cycling, running, ...).

